### PR TITLE
Fixed a issue while installing Sunrise

### DIFF
--- a/src/SunriseInstaller/Services/ErrorMessages.cs
+++ b/src/SunriseInstaller/Services/ErrorMessages.cs
@@ -17,6 +17,8 @@ public static class ErrorMessages
             UnauthorizedAccessException =>
                 "Access was denied. Choose a writable folder or run with the needed access.",
             PathTooLongException => "The selected path is too long. Choose a shorter install folder.",
+            FileNotFoundException or DirectoryNotFoundException =>
+                "An expected file was missing. See the installer log for details.",
             IOException ioException when IsDiskFull(ioException) =>
                 "The drive ran out of space. Free some space and run Repair.",
             IOException ioException when IsSharingViolation(ioException) =>

--- a/src/SunriseInstaller/Services/SunriseReleaseService.cs
+++ b/src/SunriseInstaller/Services/SunriseReleaseService.cs
@@ -34,17 +34,15 @@ public sealed class SunriseReleaseService(
 
         try
         {
-            string assetPath = Path.Combine(stagingDirectory, "release-download");
+            string dllPath = Path.Combine(stagingDirectory, "steam_api64.dll");
             if (localPayloadPath is null)
             {
-                await gitHub.DownloadAsync(release.Asset, assetPath, progress, cancellationToken);
+                await gitHub.DownloadAsync(release.Asset, dllPath, progress, cancellationToken);
             }
             else
             {
-                await CopyLocalAsync(localPayloadPath, release.Asset, assetPath, progress, cancellationToken);
+                await CopyLocalAsync(localPayloadPath, release.Asset, dllPath, progress, cancellationToken);
             }
-
-            string dllPath = Path.Combine(stagingDirectory, "steam_api64.dll");
 
             FileIntegrity.ValidateAmd64Dll(dllPath);
             string hash = await FileIntegrity.Sha256Async(dllPath, cancellationToken);


### PR DESCRIPTION
fixed a filename mismatch in SunriseReleaseService.cs. 

The release asset was downloaded to <staging>/release-download, but the next line looked for <staging>/steam_api64.dll. 

That file never existed, so FileIntegrity.ValidateAmd64Dll threw FileNotFoundException. which inherits from IOException and therefore landed in the generic "file could not be read or written" bucket in ErrorMessages. 

The Downloaded steam_api64.dll. line right before it was the success log from the download step, which is why the two messages looked contradictory.